### PR TITLE
Automatic logs and no more unsafe code.

### DIFF
--- a/FrostysQuicksilverRancher/Components/PlortUndisappearifier.cs
+++ b/FrostysQuicksilverRancher/Components/PlortUndisappearifier.cs
@@ -3,25 +3,23 @@ using SRML.SR.SaveSystem.Data;
 
 namespace FrostysQuicksilverRancher.Components
 {
-	class PlortUndisappearifier : SRBehaviour, ExtendedData.Participant
-	{
-		// Token: 0x06000029 RID: 41 RVA: 0x00002E1C File Offset: 0x0000101C
-		public void Awake()
-		{
-			QuicksilverPlortCollector component = GetComponent<QuicksilverPlortCollector>();
-			bool flag = component;
-			if (flag)
-			{
-				UnityEngine.Object.Destroy(component);
-			}
-		}
+    class PlortUndisappearifier : SRBehaviour, ExtendedData.Participant
+    {
+        public void Awake()
+        {
+            QuicksilverPlortCollector component = base.GetComponent<QuicksilverPlortCollector>();
+            if (component)
+            {
+                UnityEngine.Object.Destroy(component);
+            }
+        }
 
-		public void ReadData(CompoundDataPiece piece)
-		{
-		}
+        public void ReadData(CompoundDataPiece piece)
+        {
+        }
 
-		public void WriteData(CompoundDataPiece piece)
-		{
-		}
-	}
+        public void WriteData(CompoundDataPiece piece)
+        {
+        }
+    }
 }

--- a/FrostysQuicksilverRancher/Console.cs
+++ b/FrostysQuicksilverRancher/Console.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics;
+
+namespace FrostysQuicksilverRancher
+{
+    internal static class Console
+    {
+        [Conditional("DEBUG")]
+        public static void Log(string message, bool logToFile = true)
+            => SRML.Console.Console.Log(message, logToFile);
+
+        [Conditional("DEBUG")]
+        public static void LogError(string message, bool logToFile = true)
+            => SRML.Console.Console.LogError(message, logToFile);
+    }
+}

--- a/FrostysQuicksilverRancher/FrostysQuicksilverRancher.csproj
+++ b/FrostysQuicksilverRancher/FrostysQuicksilverRancher.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Patches\VacPatch.cs" />
     <Compile Include="Patches\ZonePatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Console.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="modinfo.json" />

--- a/FrostysQuicksilverRancher/FrostysQuicksilverRancher.csproj
+++ b/FrostysQuicksilverRancher/FrostysQuicksilverRancher.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +23,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/FrostysQuicksilverRancher/Other/Commands.cs
+++ b/FrostysQuicksilverRancher/Other/Commands.cs
@@ -25,30 +25,34 @@ namespace FrostysQuicksilverRancher.Other
                 Console.LogError("Incorrect amount of arguments!", true);
                 return false;
             }
-            bool flag = SRSingleton<SceneContext>.Instance.PlayerState.HasUpgrade(Ids.MOCHI_HACK);
-            if (flag)
+
+            if (SRSingleton<SceneContext>.Instance.PlayerState.HasUpgrade(Ids.MOCHI_HACK))
             {
                 Console.Log("Changed Vacpack renderer mode to: " + args[0], true);
+
                 if (args[0].ToLower() == "automatic")
                 {
                     Console.Log("Not implemented yet");
                     return true;
                 }
-                if (System.Enum.TryParse(args[0], out VACPACK_ENUMS vACPACK))
+
+                if (System.Enum.TryParse(args[0], out VACPACK_ENUMS VACPACK))
                 {
-                    PlayerState.AmmoMode ammoMode = (vACPACK == VACPACK_ENUMS.NIMBLE_VALLEY) ? PlayerState.AmmoMode.NIMBLE_VALLEY : PlayerState.AmmoMode.DEFAULT;
+                    PlayerState.AmmoMode ammoMode = (VACPACK == VACPACK_ENUMS.NIMBLE_VALLEY) ?
+                            PlayerState.AmmoMode.NIMBLE_VALLEY :
+                            PlayerState.AmmoMode.DEFAULT;
+
                     UnityEngine.GameObject.FindObjectOfType<VacDisplayChanger>().SetDisplayMode(ammoMode);
                 }
 
-                //foreach (VACPACK_ENUMS vacPACK in System.Enum.GetValues(typeof(VACPACK_ENUMS))) {}
-
+                //foreach (VACPACK_ENUMS vac in System.Enum.GetValues(typeof(VACPACK_ENUMS))) {}
             }
             else
             {
                 Console.Log("You have to first have bought the \"Gate Hack\" upgrade, else you can't use this command");
             }
-            return true;
 
+            return true;
         }
 
         // A list that the autocomplete references from. You must return a List<string>.

--- a/FrostysQuicksilverRancher/Patches/TestPatches.cs
+++ b/FrostysQuicksilverRancher/Patches/TestPatches.cs
@@ -11,9 +11,9 @@ namespace FrostysQuicksilverRancher.Patches
 {
     [HarmonyPatch(typeof(QuicksilverPlortCollector))]
     [HarmonyPatch("Update")]
-    unsafe public static class QuicksilverPlortCollectorPatch
+    public static class QuicksilverPlortCollectorPatch
     {
-        unsafe public static bool Prefix(QuicksilverPlortCollector __instance)
+        public static bool Prefix(QuicksilverPlortCollector __instance)
         {
             if (__instance.timeDirector.HasReached(__instance.timer))
             {
@@ -29,9 +29,9 @@ namespace FrostysQuicksilverRancher.Patches
 
     [HarmonyPatch(typeof(QuicksilverEnergyGenerator))]
     [HarmonyPatch("SetState")]
-    unsafe public static class TestPatches
+    public static class TestPatches
     {
-        unsafe public static bool Prefix(QuicksilverEnergyGenerator __instance, QuicksilverEnergyGenerator.State state, bool enableSFX)
+        public static bool Prefix(QuicksilverEnergyGenerator __instance, QuicksilverEnergyGenerator.State state, bool enableSFX)
         {
             Console.Log("Parameters are: " + state + " and " + enableSFX);
             Destroyer.Destroy(__instance.countdownUI, "QuicksilverEnergyGenerator.SetState");

--- a/FrostysQuicksilverRancher/Patches/TestPatches.cs
+++ b/FrostysQuicksilverRancher/Patches/TestPatches.cs
@@ -10,161 +10,170 @@ using FrostysQuicksilverRancher.Other;
 
 namespace FrostysQuicksilverRancher.Patches
 {
-	[HarmonyPatch(typeof(QuicksilverPlortCollector))]
-	[HarmonyPatch("Update")]
-	unsafe public static class QuicksilverPlortCollectorPatch
+    [HarmonyPatch(typeof(QuicksilverPlortCollector))]
+    [HarmonyPatch("Update")]
+    unsafe public static class QuicksilverPlortCollectorPatch
     {
-		unsafe public static bool Prefix(QuicksilverPlortCollector __instance)
+        unsafe public static bool Prefix(QuicksilverPlortCollector __instance)
         {
-			if (__instance.timeDirector.HasReached(__instance.timer))
+            if (__instance.timeDirector.HasReached(__instance.timer))
             {
-				bool isInMochiZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.MOCHI_RANCH);
-				////Console.Log("isInMochiZone: " + isInMochiZone);
-				bool isInValleyZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.VALLEY);
-				////Console.Log("isInValleyZone: " + isInValleyZone);
-				return isInMochiZone || isInValleyZone;
-			}
-			else { return false; }
-
-		}
+                bool isInMochiZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.MOCHI_RANCH);
+                //Console.Log("isInMochiZone: " + isInMochiZone);
+                bool isInValleyZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.VALLEY);
+                //Console.Log("isInValleyZone: " + isInValleyZone);
+                return isInMochiZone || isInValleyZone;
+            }
+            else { return false; }
+        }
     }
 
-	[HarmonyPatch(typeof(QuicksilverEnergyGenerator))]
+    [HarmonyPatch(typeof(QuicksilverEnergyGenerator))]
     [HarmonyPatch("SetState")]
     unsafe public static class TestPatches
     {
         unsafe public static bool Prefix(QuicksilverEnergyGenerator __instance, QuicksilverEnergyGenerator.State state, bool enableSFX)
         {
             //Console.Log("Parameters are: " + state + " and " + enableSFX);
-			Destroyer.Destroy(__instance.countdownUI, "QuicksilverEnergyGenerator.SetState");
-			//Console.Log("CountdownUI destroyed");
-			__instance.model.state = state;
-			//Console.Log("model.state setted");
+            Destroyer.Destroy(__instance.countdownUI, "QuicksilverEnergyGenerator.SetState");
+            //Console.Log("CountdownUI destroyed");
+            __instance.model.state = state;
+            //Console.Log("model.state setted");
 
-			if (__instance.model.state == QuicksilverEnergyGenerator.State.COUNTDOWN)
-			{
-				//Console.Log("if state is countdown");
+            if (__instance.model.state == QuicksilverEnergyGenerator.State.COUNTDOWN)
+            {
+                //Console.Log("if state is countdown");
 
-				__instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.countdownMinutes * 0.016666668f));
-				//Console.Log("Countdown: timer setted");
+                __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.countdownMinutes * 0.016666668f));
+                //Console.Log("Countdown: timer setted");
 
-				if (enableSFX)
-				{
-					//Console.Log("Countdown: if enable SFX");
+                if (enableSFX)
+                {
+                    //Console.Log("Countdown: if enable SFX");
 
-					SECTR_AudioSystem.Play(__instance.onCountdownCue, __instance.transform.position, false);
-					//Console.Log("Audio played");
+                    SECTR_AudioSystem.Play(__instance.onCountdownCue, __instance.transform.position, false);
+                    //Console.Log("Audio played");
+                }
 
-				}
-				bool flag = SRSingleton<SceneContext>.Instance.PlayerState.HasUpgrade(Ids.MOCHI_HACK);
-				if (flag)
-				{
-					VACPACK_ENUMS flag1 = Values.VACPACK;
-					switch (flag1)
-					{
-						case VACPACK_ENUMS.NIMBLE_VALLEY:
-							SRSingleton<SceneContext>.Instance.Player.GetComponentInChildren<WeaponVacuum>().GetComponentInChildren<VacDisplayTimer>().SetQuicksilverEnergyGenerator(__instance);
-							break;
+                if (SRSingleton<SceneContext>.Instance.PlayerState.HasUpgrade(Ids.MOCHI_HACK))
+                {
+                    VACPACK_ENUMS flag1 = Values.VACPACK;
+                    switch (flag1)
+                    {
+                        case VACPACK_ENUMS.NIMBLE_VALLEY:
+                            SRSingleton<SceneContext>.Instance.Player
+                                .GetComponentInChildren<WeaponVacuum>()
+                                .GetComponentInChildren<VacDisplayTimer>()
+                                .SetQuicksilverEnergyGenerator(__instance);
+                            break;
 
-						case VACPACK_ENUMS.DEFAULT:
-							break;
+                        case VACPACK_ENUMS.DEFAULT:
+                            break;
 
-						case VACPACK_ENUMS.AUTOMATIC:
-							ZoneDirector.Zone currentZone = SRSingleton<SceneContext>.Instance.PlayerZoneTracker.GetCurrentZone();
-							PlayerState.AmmoMode ammoMode = (currentZone == ZoneDirector.Zone.MOCHI_RANCH || currentZone == ZoneDirector.Zone.VALLEY) ? PlayerState.AmmoMode.NIMBLE_VALLEY : PlayerState.AmmoMode.DEFAULT;
-							if (ammoMode == PlayerState.AmmoMode.NIMBLE_VALLEY)
-								SRSingleton<SceneContext>.Instance.Player.GetComponentInChildren<WeaponVacuum>().GetComponentInChildren<VacDisplayTimer>().SetQuicksilverEnergyGenerator(__instance);
-							break;
-					}
-				}
-                else { SRSingleton<SceneContext>.Instance.Player.GetComponentInChildren<WeaponVacuum>().GetComponentInChildren<VacDisplayTimer>().SetQuicksilverEnergyGenerator(__instance); }
+                        case VACPACK_ENUMS.AUTOMATIC:
+                            ZoneDirector.Zone currentZone = SRSingleton<SceneContext>.Instance.PlayerZoneTracker.GetCurrentZone();
 
-				//Console.Log("Countdown: VacDisplayTimer generator setted");
+                            PlayerState.AmmoMode ammoMode = (currentZone == ZoneDirector.Zone.MOCHI_RANCH || currentZone == ZoneDirector.Zone.VALLEY) ?
+                                PlayerState.AmmoMode.NIMBLE_VALLEY :
+                                PlayerState.AmmoMode.DEFAULT;
 
-				__instance.countdownUI = UnityEngine.Object.Instantiate<GameObject>(__instance.countdownUIPrefab);
-				//Console.Log("Countdown: countdownUI created");
+                            if (ammoMode == PlayerState.AmmoMode.NIMBLE_VALLEY)
+                            {
+                                SRSingleton<SceneContext>.Instance.Player
+                                    .GetComponentInChildren<WeaponVacuum>()
+                                    .GetComponentInChildren<VacDisplayTimer>()
+                                    .SetQuicksilverEnergyGenerator(__instance);
+                            }
 
-				__instance.countdownUI.GetComponent<HUDCountdownUI>().SetCountdownTime(__instance.countdownMinutes);
-				//Console.Log("Countdown: Timer time setted");
+                            break;
+                    }
+                }
+                else
+                {
+                    SRSingleton<SceneContext>.Instance.Player
+                        .GetComponentInChildren<WeaponVacuum>()
+                        .GetComponentInChildren<VacDisplayTimer>()
+                        .SetQuicksilverEnergyGenerator(__instance);
+                }
 
-			}
-			else if (__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE)
-			{
-				//Console.Log("if state is active");
+                //Console.Log("Countdown: VacDisplayTimer generator setted");
 
-				__instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.activeHours));
-				//Console.Log("Active: Timer setted");
+                __instance.countdownUI = UnityEngine.Object.Instantiate<GameObject>(__instance.countdownUIPrefab);
+                //Console.Log("Countdown: countdownUI created");
 
-			}
-			else if (__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN)
-			{
-				//Console.Log("if state is cooldown");
+                __instance.countdownUI.GetComponent<HUDCountdownUI>().SetCountdownTime(__instance.countdownMinutes);
+                //Console.Log("Countdown: Timer time setted");
+            }
+            else if (__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE)
+            {
+                //Console.Log("if state is active");
 
-				__instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.cooldownHours));
-				//Console.Log("Cooldown: timer setted");
+                __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.activeHours));
+                //Console.Log("Active: Timer setted");
+            }
+            else if (__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN)
+            {
+                //Console.Log("if state is cooldown");
 
-				if (enableSFX)
-				{
-					//Console.Log("Cooldown: if enableSFX");
+                __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.cooldownHours));
+                //Console.Log("Cooldown: timer setted");
 
-					SECTR_AudioSystem.Play(__instance.onCooldownCue, __instance.transform.position, false);
-					//Console.Log("Cooldown: Play first audio");
+                if (enableSFX)
+                {
+                    //Console.Log("Cooldown: if enableSFX");
 
-					SECTR_AudioSystem.Play(__instance.onCooldownCue2D, Vector3.zero, false);
-					//Console.Log("Cooldown: Play second audio");
+                    SECTR_AudioSystem.Play(__instance.onCooldownCue, __instance.transform.position, false);
+                    //Console.Log("Cooldown: Play first audio");
 
-				}
-			}
-			else
-			{
-				//Console.Log("if everything is null");
+                    SECTR_AudioSystem.Play(__instance.onCooldownCue2D, Vector3.zero, false);
+                    //Console.Log("Cooldown: Play second audio");
+                }
+            }
+            else
+            {
+                //Console.Log("if everything is null");
 
-				__instance.model.timer = null;
-				//Console.Log("Null: Timer setted");
+                __instance.model.timer = null;
+                //Console.Log("Null: Timer setted");
 
-				if (enableSFX)
-				{
-					//Console.Log("Null: if enableSFX");
+                if (enableSFX)
+                {
+                    //Console.Log("Null: if enableSFX");
 
-					SECTR_AudioSystem.Play(__instance.onInactiveCue, __instance.transform.position, false);
-					//Console.Log("Null: Play audio");
+                    SECTR_AudioSystem.Play(__instance.onInactiveCue, __instance.transform.position, false);
+                    //Console.Log("Null: Play audio");
+                }
+            }
+            if (__instance.inactiveFX != null)
+            {
+                //Console.Log("if inactive FX is null");
 
-				}
-			}
-			if (__instance.inactiveFX != null)
-			{
-				//Console.Log("if inactive FX is null");
+                __instance.inactiveFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.INACTIVE);
+                //Console.Log("inactive FX setted");
+            }
+            if (__instance.activeFX != null)
+            {
+                //Console.Log("if activeFX is null");
 
-				__instance.inactiveFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.INACTIVE);
-				//Console.Log("inactive FX setted");
+                __instance.activeFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE);
+                //Console.Log("activeFX setted");
 
-			}
-			if (__instance.activeFX != null)
-			{
-				//Console.Log("if activeFX is null");
+            }
+            if (__instance.cooldownFX != null)
+            {
+                //Console.Log("if cooldownFX is null");
 
-				__instance.activeFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE);
-				//Console.Log("activeFX setted");
+                __instance.cooldownFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN);
+                //Console.Log("cooldownFX setted");
+            }
+            if (__instance.onStateChanged != null)
+            {
+                //Console.Log("if onstatechanged is null");
 
-			}
-			if (__instance.cooldownFX != null)
-			{
-				//Console.Log("if cooldownFX is null");
-
-				__instance.cooldownFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN);
-				//Console.Log("cooldownFX setted");
-
-			}
-			if (__instance.onStateChanged != null)
-			{
-				//Console.Log("if onstatechanged is null");
-
-				__instance.onStateChanged();
-				//Console.Log("onstatechanged setted");
-
-			}
-			return false;
+                __instance.onStateChanged();
+                //Console.Log("onstatechanged setted");
+            }
+            return false;
         }
-
     }
 }

--- a/FrostysQuicksilverRancher/Patches/TestPatches.cs
+++ b/FrostysQuicksilverRancher/Patches/TestPatches.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 
 using Configs;
-using SRML.Console;
 using HarmonyLib;
 
 using MonomiPark.SlimeRancher.Regions;
@@ -19,9 +18,9 @@ namespace FrostysQuicksilverRancher.Patches
             if (__instance.timeDirector.HasReached(__instance.timer))
             {
                 bool isInMochiZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.MOCHI_RANCH);
-                //Console.Log("isInMochiZone: " + isInMochiZone);
+                Console.Log("isInMochiZone: " + isInMochiZone);
                 bool isInValleyZone = __instance.GetComponent<RegionMember>().IsInZone(ZoneDirector.Zone.VALLEY);
-                //Console.Log("isInValleyZone: " + isInValleyZone);
+                Console.Log("isInValleyZone: " + isInValleyZone);
                 return isInMochiZone || isInValleyZone;
             }
             else { return false; }
@@ -34,25 +33,25 @@ namespace FrostysQuicksilverRancher.Patches
     {
         unsafe public static bool Prefix(QuicksilverEnergyGenerator __instance, QuicksilverEnergyGenerator.State state, bool enableSFX)
         {
-            //Console.Log("Parameters are: " + state + " and " + enableSFX);
+            Console.Log("Parameters are: " + state + " and " + enableSFX);
             Destroyer.Destroy(__instance.countdownUI, "QuicksilverEnergyGenerator.SetState");
-            //Console.Log("CountdownUI destroyed");
+            Console.Log("CountdownUI destroyed");
             __instance.model.state = state;
-            //Console.Log("model.state setted");
+            Console.Log("model.state setted");
 
             if (__instance.model.state == QuicksilverEnergyGenerator.State.COUNTDOWN)
             {
-                //Console.Log("if state is countdown");
+                Console.Log("if state is countdown");
 
                 __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.countdownMinutes * 0.016666668f));
-                //Console.Log("Countdown: timer setted");
+                Console.Log("Countdown: timer setted");
 
                 if (enableSFX)
                 {
-                    //Console.Log("Countdown: if enable SFX");
+                    Console.Log("Countdown: if enable SFX");
 
                     SECTR_AudioSystem.Play(__instance.onCountdownCue, __instance.transform.position, false);
-                    //Console.Log("Audio played");
+                    Console.Log("Audio played");
                 }
 
                 if (SRSingleton<SceneContext>.Instance.PlayerState.HasUpgrade(Ids.MOCHI_HACK))
@@ -96,82 +95,82 @@ namespace FrostysQuicksilverRancher.Patches
                         .SetQuicksilverEnergyGenerator(__instance);
                 }
 
-                //Console.Log("Countdown: VacDisplayTimer generator setted");
+                Console.Log("Countdown: VacDisplayTimer generator setted");
 
                 __instance.countdownUI = UnityEngine.Object.Instantiate<GameObject>(__instance.countdownUIPrefab);
-                //Console.Log("Countdown: countdownUI created");
+                Console.Log("Countdown: countdownUI created");
 
                 __instance.countdownUI.GetComponent<HUDCountdownUI>().SetCountdownTime(__instance.countdownMinutes);
-                //Console.Log("Countdown: Timer time setted");
+                Console.Log("Countdown: Timer time setted");
             }
             else if (__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE)
             {
-                //Console.Log("if state is active");
+                Console.Log("if state is active");
 
                 __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.activeHours));
-                //Console.Log("Active: Timer setted");
+                Console.Log("Active: Timer setted");
             }
             else if (__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN)
             {
-                //Console.Log("if state is cooldown");
+                Console.Log("if state is cooldown");
 
                 __instance.model.timer = new double?(__instance.timeDirector.HoursFromNow(__instance.cooldownHours));
-                //Console.Log("Cooldown: timer setted");
+                Console.Log("Cooldown: timer setted");
 
                 if (enableSFX)
                 {
-                    //Console.Log("Cooldown: if enableSFX");
+                    Console.Log("Cooldown: if enableSFX");
 
                     SECTR_AudioSystem.Play(__instance.onCooldownCue, __instance.transform.position, false);
-                    //Console.Log("Cooldown: Play first audio");
+                    Console.Log("Cooldown: Play first audio");
 
                     SECTR_AudioSystem.Play(__instance.onCooldownCue2D, Vector3.zero, false);
-                    //Console.Log("Cooldown: Play second audio");
+                    Console.Log("Cooldown: Play second audio");
                 }
             }
             else
             {
-                //Console.Log("if everything is null");
+                Console.Log("if everything is null");
 
                 __instance.model.timer = null;
-                //Console.Log("Null: Timer setted");
+                Console.Log("Null: Timer setted");
 
                 if (enableSFX)
                 {
-                    //Console.Log("Null: if enableSFX");
+                    Console.Log("Null: if enableSFX");
 
                     SECTR_AudioSystem.Play(__instance.onInactiveCue, __instance.transform.position, false);
-                    //Console.Log("Null: Play audio");
+                    Console.Log("Null: Play audio");
                 }
             }
             if (__instance.inactiveFX != null)
             {
-                //Console.Log("if inactive FX is null");
+                Console.Log("if inactive FX is null");
 
                 __instance.inactiveFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.INACTIVE);
-                //Console.Log("inactive FX setted");
+                Console.Log("inactive FX setted");
             }
             if (__instance.activeFX != null)
             {
-                //Console.Log("if activeFX is null");
+                Console.Log("if activeFX is null");
 
                 __instance.activeFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.ACTIVE);
-                //Console.Log("activeFX setted");
+                Console.Log("activeFX setted");
 
             }
             if (__instance.cooldownFX != null)
             {
-                //Console.Log("if cooldownFX is null");
+                Console.Log("if cooldownFX is null");
 
                 __instance.cooldownFX.SetActive(__instance.model.state == QuicksilverEnergyGenerator.State.COOLDOWN);
-                //Console.Log("cooldownFX setted");
+                Console.Log("cooldownFX setted");
             }
             if (__instance.onStateChanged != null)
             {
-                //Console.Log("if onstatechanged is null");
+                Console.Log("if onstatechanged is null");
 
                 __instance.onStateChanged();
-                //Console.Log("onstatechanged setted");
+                Console.Log("onstatechanged setted");
             }
             return false;
         }

--- a/FrostysQuicksilverRancher/Patches/VacPatch.cs
+++ b/FrostysQuicksilverRancher/Patches/VacPatch.cs
@@ -1,5 +1,4 @@
 ﻿using Configs;
-using SRML.Console;
 using HarmonyLib;
 using FrostysQuicksilverRancher.Other;
 

--- a/FrostysQuicksilverRancher/Patches/VacPatch.cs
+++ b/FrostysQuicksilverRancher/Patches/VacPatch.cs
@@ -5,34 +5,36 @@ using FrostysQuicksilverRancher.Other;
 
 namespace FrostysQuicksilverRancher.Patches
 {
-	[HarmonyPatch(typeof(VacDisplayChanger))]
-	[HarmonyPatch("Awake")]
-	public static class VacPatch
-	{
-		public static void Postfix(VacDisplayChanger __instance)
-		{
-			Console.Log("Awake with Vacpack enum: " + Values.VACPACK);
-			bool flag = __instance.playerState.HasUpgrade(Ids.MOCHI_HACK);
-			if (flag)
-			{
-				VACPACK_ENUMS flag1 = Values.VACPACK;
-				switch (flag1)
-				{
-					case VACPACK_ENUMS.NIMBLE_VALLEY:
-						__instance.SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
-						break;
+    [HarmonyPatch(typeof(VacDisplayChanger))]
+    [HarmonyPatch("Awake")]
+    public static class VacPatch
+    {
+        public static void Postfix(VacDisplayChanger __instance)
+        {
+            Console.Log("Awake with Vacpack enum: " + Values.VACPACK);
+            bool flag = __instance.playerState.HasUpgrade(Ids.MOCHI_HACK);
+            if (flag)
+            {
+                VACPACK_ENUMS flag1 = Values.VACPACK;
+                switch (flag1)
+                {
+                    case VACPACK_ENUMS.NIMBLE_VALLEY:
+                        __instance.SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
+                        break;
 
-					case VACPACK_ENUMS.DEFAULT:
-						__instance.SetDisplayMode(PlayerState.AmmoMode.DEFAULT);
-						break;
+                    case VACPACK_ENUMS.DEFAULT:
+                        __instance.SetDisplayMode(PlayerState.AmmoMode.DEFAULT);
+                        break;
 
-					case VACPACK_ENUMS.AUTOMATIC:
-						ZoneDirector.Zone currentZone = SRSingleton<SceneContext>.Instance.PlayerZoneTracker.GetCurrentZone();
-						PlayerState.AmmoMode ammoMode = (currentZone == ZoneDirector.Zone.MOCHI_RANCH || currentZone == ZoneDirector.Zone.VALLEY) ? PlayerState.AmmoMode.NIMBLE_VALLEY : PlayerState.AmmoMode.DEFAULT;
-						__instance.SetDisplayMode(ammoMode);
-						break;
-				}
-			}
-		}
-	}
+                    case VACPACK_ENUMS.AUTOMATIC:
+                        ZoneDirector.Zone currentZone = SRSingleton<SceneContext>.Instance.PlayerZoneTracker.GetCurrentZone();
+                        PlayerState.AmmoMode ammoMode = (currentZone == ZoneDirector.Zone.MOCHI_RANCH || currentZone == ZoneDirector.Zone.VALLEY)
+                            ? PlayerState.AmmoMode.NIMBLE_VALLEY :
+                            PlayerState.AmmoMode.DEFAULT;
+                        __instance.SetDisplayMode(ammoMode);
+                        break;
+                }
+            }
+        }
+    }
 }

--- a/FrostysQuicksilverRancher/Patches/ZonePatch.cs
+++ b/FrostysQuicksilverRancher/Patches/ZonePatch.cs
@@ -8,8 +8,7 @@ namespace FrostysQuicksilverRancher.Patches
 	{
 		public static void Postfix(ZoneDirector.Zone zone)
 		{
-			bool flag = zone == ZoneDirector.Zone.MOCHI_RANCH;
-			if (flag)
+			if (zone == ZoneDirector.Zone.MOCHI_RANCH)
 			{
 				SRSingleton<SceneContext>.Instance.PlayerState.CheckAllUpgradeLockers();
 			}

--- a/FrostysQuicksilverRancher/Patches/onTriggerEnterPatch.cs
+++ b/FrostysQuicksilverRancher/Patches/onTriggerEnterPatch.cs
@@ -5,21 +5,22 @@ using FrostysQuicksilverRancher.Other;
 
 namespace FrostysQuicksilverRancher.Patches
 {
-	[HarmonyPatch(typeof(AmmoModeTrigger))]
-	[HarmonyPatch("OnTriggerEnter")]
-	public static class OnTriggerEnterPatch
-	{
-		public static bool Prefix(AmmoModeTrigger __instance)
-		{
-			bool flag = __instance.playerState.HasUpgrade(Ids.MOCHI_HACK);
-			if (flag)
-			{
-				if (Values.VACPACK == VACPACK_ENUMS.AUTOMATIC)
-					GameObject.FindObjectOfType<VacDisplayChanger>().SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
-				return false;
-			}
-            else { return true;  }
+    [HarmonyPatch(typeof(AmmoModeTrigger))]
+    [HarmonyPatch("OnTriggerEnter")]
+    public static class OnTriggerEnterPatch
+    {
+        public static bool Prefix(AmmoModeTrigger __instance)
+        {
+            if (__instance.playerState.HasUpgrade(Ids.MOCHI_HACK))
+            {
+                if (Values.VACPACK == VACPACK_ENUMS.AUTOMATIC)
+                {
+                    GameObject.FindObjectOfType<VacDisplayChanger>().SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
+                }
 
-		}
-	}
+                return false;
+            }
+            else { return true; }
+        }
+    }
 }

--- a/FrostysQuicksilverRancher/Patches/onTriggerExitPatch.cs
+++ b/FrostysQuicksilverRancher/Patches/onTriggerExitPatch.cs
@@ -5,20 +5,22 @@ using FrostysQuicksilverRancher.Other;
 
 namespace FrostysQuicksilverRancher.Patches
 {
-	[HarmonyPatch(typeof(AmmoModeTrigger))]
-	[HarmonyPatch("OnTriggerExit")]
-	public static class OnTriggerExitPatch
-	{
-		public static bool Prefix(AmmoModeTrigger __instance)
-		{
-			bool flag = __instance.playerState.HasUpgrade(Ids.MOCHI_HACK);
-			if (flag)
-			{
-				if (Values.VACPACK == VACPACK_ENUMS.AUTOMATIC)
-					GameObject.FindObjectOfType<VacDisplayChanger>().SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
-				return false;
-			}
-			else { return true; }
-		}
-	}
+    [HarmonyPatch(typeof(AmmoModeTrigger))]
+    [HarmonyPatch("OnTriggerExit")]
+    public static class OnTriggerExitPatch
+    {
+        public static bool Prefix(AmmoModeTrigger __instance)
+        {
+            if (__instance.playerState.HasUpgrade(Ids.MOCHI_HACK))
+            {
+                if (Values.VACPACK == VACPACK_ENUMS.AUTOMATIC)
+                {
+                    GameObject.FindObjectOfType<VacDisplayChanger>().SetDisplayMode(PlayerState.AmmoMode.NIMBLE_VALLEY);
+                }
+
+                return false;
+            }
+            else { return true; }
+        }
+    }
 }


### PR DESCRIPTION
I added some wrapper methods for `SRML.Console` that will only be called when it's compiled in the Debug configuration. In Release mode the compiler will automatically remove these method calls.

This should save some time commenting and uncommenting code.

I also changed the language version to 8.0 and enabled unsafe code for both Release and Debug configurations, meaning the code no longer needs `unsafe` blocks, which might have fixed potential memory leaks.